### PR TITLE
Ensure namenode safemode check is performed on active ones and not only the first one

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -659,8 +659,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       }
 
     val action = actionClass.getField("SAFEMODE_GET").get(null)
-    val method = dfs.getClass().getMethod("setSafeMode", action.getClass())
-    method.invoke(dfs, action).asInstanceOf[Boolean]
+    val method = dfs.getClass().getMethod("setSafeMode", action.getClass(), java.lang.Boolean.TYPE)
+    method.invoke(dfs, action, true: java.lang.Boolean).asInstanceOf[Boolean]
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

FsHistoryProvider of spark use an API to check if namenode is in safemode but only requesting the first namenode and then loop on this check.
This patch ensure namenode safemode check is performed on active namenodes and not only the first one
## How was this patch tested?

Tested manually
